### PR TITLE
New simplified parsing, streaming API available

### DIFF
--- a/Playgrounds/Example Languages.playground/Contents.swift
+++ b/Playgrounds/Example Languages.playground/Contents.swift
@@ -4,6 +4,8 @@ import Foundation
 import STLR
 import OysterKit
 
+
+
 guard let grammarSource = try? String(contentsOfFile: "/Volumes/Personal/SPM/XMLDecoder/XML.stlr") else {
     fatalError("Could not load grammar")
 }
@@ -32,7 +34,7 @@ for streamedToken in TokenStream(csvSource, using: STLRParser(source:"value = !\
     print("Got \(streamedToken.token)='\(csvSource[streamedToken.range])'")
 }
 
-let tree = try? AbstractSyntaxTreeConstructor().build(xmlSource, using: xmlLanguage)
+let tree = try? AbstractSyntaxTreeConstructor().build("<message>DataData</message>", using: xmlLanguage)
 
 print(tree?.description ?? "Failed")
 

--- a/Playgrounds/Example Languages.playground/timeline.xctimeline
+++ b/Playgrounds/Example Languages.playground/timeline.xctimeline
@@ -3,17 +3,17 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "file:///Volumes/Personal/SPM/OysterKit/Playgrounds/Example%20Languages.playground#CharacterRangeLen=7&amp;CharacterRangeLoc=1106&amp;EndingColumnNumber=16&amp;EndingLineNumber=43&amp;StartingColumnNumber=9&amp;StartingLineNumber=43&amp;Timestamp=539067696.83023"
+         documentLocation = "file:///Volumes/Personal/SPM/OysterKit/Playgrounds/Example%20Languages.playground#CharacterRangeLen=7&amp;CharacterRangeLoc=1128&amp;EndingColumnNumber=16&amp;EndingLineNumber=45&amp;StartingColumnNumber=9&amp;StartingLineNumber=45&amp;Timestamp=539117686.6937439"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "file:///Volumes/Personal/SPM/OysterKit/Playgrounds/Example%20Languages.playground#CharacterRangeLen=0&amp;CharacterRangeLoc=1090&amp;EndingColumnNumber=68&amp;EndingLineNumber=40&amp;StartingColumnNumber=68&amp;StartingLineNumber=40&amp;Timestamp=539067696.830422"
+         documentLocation = "file:///Volumes/Personal/SPM/OysterKit/Playgrounds/Example%20Languages.playground#CharacterRangeLen=0&amp;CharacterRangeLoc=1112&amp;EndingColumnNumber=68&amp;EndingLineNumber=42&amp;StartingColumnNumber=68&amp;StartingLineNumber=42&amp;Timestamp=539117686.693898"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "file:///Volumes/Personal/SPM/OysterKit/Playgrounds/Example%20Languages.playground#CharacterRangeLen=0&amp;CharacterRangeLoc=1090&amp;EndingColumnNumber=68&amp;EndingLineNumber=40&amp;StartingColumnNumber=68&amp;StartingLineNumber=40&amp;Timestamp=539067696.830557"
+         documentLocation = "file:///Volumes/Personal/SPM/OysterKit/Playgrounds/Example%20Languages.playground#CharacterRangeLen=0&amp;CharacterRangeLoc=1112&amp;EndingColumnNumber=68&amp;EndingLineNumber=42&amp;StartingColumnNumber=68&amp;StartingLineNumber=42&amp;Timestamp=539117686.694005"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/Sources/OysterKit/Parsing/Intermediate Representations/AbstractSyntaxTree+Test.swift
+++ b/Sources/OysterKit/Parsing/Intermediate Representations/AbstractSyntaxTree+Test.swift
@@ -1,0 +1,50 @@
+//    Copyright (c) 2018, RED When Excited
+//    All rights reserved.
+//
+//    Redistribution and use in source and binary forms, with or without
+//    modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+//    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+//    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+//    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+
+extension HomogenousTree {
+    func nodeAtPath(_ path: [String])->HomogenousTree?{
+        guard let nextNode = path.first else {
+            return self
+        }
+        
+        for child in children {
+            if "\(child.token)" == nextNode {
+                return child.nodeAtPath(Array(path.dropFirst()))
+            }
+        }
+        
+        return nil
+    }
+    
+    func isSet(annotation: RuleAnnotation)->Bool{
+        return annotations.filter({$0.key == annotation}).count == 1
+    }
+    
+    func value(annotation: RuleAnnotation)->RuleAnnotationValue?{
+        return annotations.filter({$0.key == annotation}).first?.value
+    }
+
+}

--- a/Sources/OysterKit/Parsing/Intermediate Representations/AbstractSyntaxTree.swift
+++ b/Sources/OysterKit/Parsing/Intermediate Representations/AbstractSyntaxTree.swift
@@ -50,6 +50,7 @@ public struct HomogenousTree : AbstractSyntaxTree, CustomStringConvertible {
         token = node.token
         matchedString = String(source[node.range])
         children = try node.children.map({ try HomogenousTree(with:$0, from: source)})
+        annotations = node.annotations
     }
     
     /// The captured `Token`
@@ -61,8 +62,25 @@ public struct HomogenousTree : AbstractSyntaxTree, CustomStringConvertible {
     /// Any sub-nodes in the tree
     public let     children      : [HomogenousTree]
     
+    /// Any associated annotations made on the node
+    public      let annotations: [RuleAnnotation : RuleAnnotationValue]
+
+    
     private func pretify(prefix:String = "")->String{
-        return "\(prefix)\(token) \(children.count > 0 ? "" : "- '\(matchedString.escaped)'")\(children.count > 0 ? children.reduce("\n", { (previous, current) -> String in return previous+current.pretify(prefix:prefix+"\t")}) : "\n")"
+        let annotatedWith : String = annotations.reduce("", {(last,pair)->String in
+            let label = "\(pair.key)"
+            let value : String
+            switch pair.value {
+            case .set:
+                value = ""
+            case .string(let string):
+                value = "(\"\(string)\")"
+            default:
+                value = "(\(pair.value))"
+            }
+            return last + "@\(label)\(value) "
+        })
+        return "\(prefix)\(annotatedWith)\(token) \(children.count > 0 ? "" : "- '\(matchedString.escaped)'")\(children.count > 0 ? children.reduce("\n", { (previous, current) -> String in return previous+current.pretify(prefix:prefix+"\t")}) : "\n")"
     }
     
     /// A well formatted description of this branch of the tree

--- a/Sources/OysterKit/Parsing/Intermediate Representations/AbstractSyntaxTreeConstructor.swift
+++ b/Sources/OysterKit/Parsing/Intermediate Representations/AbstractSyntaxTreeConstructor.swift
@@ -155,9 +155,8 @@ public class AbstractSyntaxTreeConstructor  {
         self.source  = source
         self.scalars = source.unicodeScalars
         
-        let _ = language.build(intermediateRepresentation: self, using: Lexer(source: source))
-        
         do {
+            try ParsingStrategy.parse(source, using: language, with: Lexer.self, into: self)
             let topNode : IntermediateRepresentationNode
             
             guard let topNodes = nodeStack.top?.nodes, topNodes.count > 0 else {
@@ -167,7 +166,7 @@ public class AbstractSyntaxTreeConstructor  {
             
             if topNodes.count > 1 {
                 // Wrap it in a single node
-                topNode = IntermediateRepresentationNode(for: transientTokenValue.token, at: topNodes.combinedRange, annotations: [:])
+                topNode = IntermediateRepresentationNode(for: LabelledToken(withLabel: "root"), at: topNodes.combinedRange, children: topNodes , annotations: [:])
             } else {
                 topNode = topNodes[0]
             }

--- a/Sources/OysterKit/Parsing/Intermediate Representations/HeterogenousAST.swift
+++ b/Sources/OysterKit/Parsing/Intermediate Representations/HeterogenousAST.swift
@@ -29,6 +29,7 @@ import Foundation
  Provides a default implementation of an `ASTNodeConstructor` that is expected to construct nodes that can have different fundamental data types. All nodes
  are of type `HeterogeneousNode`.
 */
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 public final class DefaultHeterogenousConstructor : ASTNodeConstructor{
     /// All nodes must conform to the protocol `HeterogeneousNode`
     public typealias NodeType =  HeterogeneousNode
@@ -111,9 +112,11 @@ public final class DefaultHeterogenousConstructor : ASTNodeConstructor{
 }
 
 /// The default implementation of a `HeterogenousAST` using the `DefaultHeterogenousConstructor`
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 public typealias DefaultHeterogeneousAST = HeterogenousAST<HeterogeneousNode,DefaultHeterogenousConstructor>
 
 /// The base class for any 'HeterogenousAST'
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 public final class HeterogenousAST<NodeType : ValuedNode, Constructor : ASTNodeConstructor> : HomogenousAST<NodeType,Constructor> where Constructor.NodeType == NodeType{
     
 }

--- a/Sources/OysterKit/Parsing/Intermediate Representations/HeterogenousNode.swift
+++ b/Sources/OysterKit/Parsing/Intermediate Representations/HeterogenousNode.swift
@@ -27,6 +27,7 @@ import Foundation
 /**
  An extension of the base `Node` type used by the standard ASTs that supports values of type `Any`. This is used primarily by `HeterogeousAST`s
  */
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 public protocol ValuedNode : Node {
     /**
      Create a new instance
@@ -43,6 +44,7 @@ public protocol ValuedNode : Node {
 }
 
 /// A set of extensions to the `ValuedNode` protocol to provide default behaviour
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 public extension ValuedNode{
     
     /// A human readable description of the node
@@ -103,6 +105,7 @@ public extension ValuedNode{
 }
 
 /// An extension for any collection containing a `ValuedNode`
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 public extension Collection where Iterator.Element : ValuedNode {
     
     /**
@@ -154,6 +157,7 @@ public extension Collection where Iterator.Element : ValuedNode {
 /**
  The default implementation of `ValuedNode`.
  */
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 public struct HeterogeneousNode : ValuedNode {
     /// The token created
     public      let token       : Token

--- a/Sources/OysterKit/Parsing/Intermediate Representations/HomogenousAST.swift
+++ b/Sources/OysterKit/Parsing/Intermediate Representations/HomogenousAST.swift
@@ -28,6 +28,7 @@ import Foundation
  `ASTNodeConstructor`s are responsible for building the data-structures used by the default homogenous and heterogenous `IntermediateRepresentations`. They
   allow you to, by providing your own implementations, control the behaviour of `Node` creation of those default implementations.
  */
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 public protocol ASTNodeConstructor{
     // The type of Node that the the implementation manages
     associatedtype  NodeType : Node
@@ -81,6 +82,7 @@ public protocol ASTNodeConstructor{
 /**
  A default constructor implementation which can be specialised for specific node types.
 */
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 final class DefaultConstructor<N:Node> : ASTNodeConstructor{
     /// The `Node` implementation to be used
     typealias NodeType = N
@@ -157,6 +159,7 @@ final class DefaultConstructor<N:Node> : ASTNodeConstructor{
 }
 
 /// A default concrete implementation of a `HomogenousAST` which uses the `DefaultConstructor`
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 final public class DefaultHomogenousAST<NodeType:Node> : HomogenousAST<NodeType, DefaultConstructor<NodeType>>{
     required public init() {
         super.init()
@@ -169,6 +172,7 @@ final public class DefaultHomogenousAST<NodeType:Node> : HomogenousAST<NodeType,
  
  -SeeAlso: DefaultHomogenousAST<NodeType:Node> which provides a default implementation using `DefaultConstructor<NodeType:Node>`
  */
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 public class HomogenousAST<NodeType, Constructor : ASTNodeConstructor> : IntermediateRepresentation where Constructor.NodeType == NodeType{
     /// The original scalars view
     private var     scalars   : String.UnicodeScalarView!

--- a/Sources/OysterKit/Parsing/Intermediate Representations/HomogenousNode.swift
+++ b/Sources/OysterKit/Parsing/Intermediate Representations/HomogenousNode.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 public struct HomogenousNode : Node {
     /// The token representing the match
     public      let token       : Token
@@ -39,6 +40,7 @@ public struct HomogenousNode : Node {
 }
 
 /// An extension providing convience methods for reporting the underlying matched string captured by the node
+@available(*, deprecated, message: "Use AbstractSyntaxTree() instead")
 public extension Node{
     
     /**

--- a/Sources/OysterKit/Parsing/Language.swift
+++ b/Sources/OysterKit/Parsing/Language.swift
@@ -162,6 +162,7 @@ public extension Language {
      - Parameter using: A pre-initialized instance of a `LexicalAnalyzer`
      - Returns: The finished `IntermediateRepresentation`
     */
+    @available(*, deprecated, message: "Use AbstractSyntaxTreeConstructor().build() instead")
     public func build<IR:IntermediateRepresentation>(intermediateRepresentation ir:IR, using lexer:LexicalAnalyzer)->IR{
         let lexer = lexer
         var success : Bool
@@ -210,6 +211,7 @@ public extension Language {
      - Parameter using: A pre-initialized instance of a `LexicalAnalyzer`
      - Returns: The finished `IntermediateRepresentation`
      */
+    @available(*, deprecated, message: "Use AbstractSyntaxTreeConstructor().build() instead")
     public func build<IR:IntermediateRepresentation>(using lexer:LexicalAnalyzer)->IR{
         return build(intermediateRepresentation: IR(), using: lexer)
     }
@@ -221,6 +223,7 @@ public extension Language {
      - Parameter source: The string to parse
      - Returns: The finished `IntermediateRepresentation`
      */
+    @available(*, deprecated, message: "Use AbstractSyntaxTreeConstructor().build() instead")
     public func build<IR:IntermediateRepresentation>(source:String)->IR{
         return build(using: Lexer(source: source))
     }

--- a/Sources/OysterKit/Parsing/Nodes.swift
+++ b/Sources/OysterKit/Parsing/Nodes.swift
@@ -47,4 +47,16 @@ public extension Collection where Iterator.Element : Node {
         
         return finalRange
     }
+    
+    /**
+     Returns a new ``Collection`` with any transient nodes filtered out
+     */
+    public var perpetual : [Element] {        
+        return filter(){ (node)->Bool in
+            if node.token.transient || node.annotations[RuleAnnotation.transient] != nil{
+                return false
+            }
+            return true
+        }
+    }
 }

--- a/Sources/OysterKit/Parsing/Stream.swift
+++ b/Sources/OysterKit/Parsing/Stream.swift
@@ -34,6 +34,7 @@ public extension Language{
      - Parameter lexer: The `LexicalAnalyzer` to use
      - Returns: A sequence of `Node`s
     */
+    @available(*, deprecated, message: "Use TokenStream() instead")
     public func stream<N:Node,L:LexicalAnalyzer>(lexer:L)->AnySequence<N>{
         return AnySequence<N>(StreamRepresentation<N,L>(source: lexer.source, language: self))
     }
@@ -43,6 +44,7 @@ public extension Language{
      
     - Returns: A sequence of `Node`s
      */
+    @available(*, deprecated, message: "Use TokenStream() instead")
     public func stream<N:Node>(source:String)->AnySequence<N>{
         return stream(lexer: Lexer(source: source))
     }
@@ -52,6 +54,7 @@ public extension Language{
 /**
  A default constructor to be used for streams. Unlike AST constructors it does not attempt to maintain any kind of hierarchy of nodes
  */
+@available(*, deprecated, message: "Use TokenStream() instead")
 final public class StreamConstructor<NodeType:Node> : ASTNodeConstructor{
     
     /// Creates a new instance of the constructor
@@ -116,6 +119,7 @@ final public class StreamConstructor<NodeType:Node> : ASTNodeConstructor{
  A lazy iterator that parses for the next `Token` each time the consumer of the `IteratorProtocol` requests the `next()` entry. These cannot
  be created directly but are supplied from the `stream()` functions of a `Language`
  */
+@available(*, deprecated, message: "Use TokenStream() instead")
 public class NodeIterator<N:Node> : IteratorProtocol{
     /// Elements are always `Node`s
     public typealias Element = N
@@ -204,6 +208,7 @@ public class NodeIterator<N:Node> : IteratorProtocol{
 /**
  Enables a lazy sequence of `Nodes` to be created from a source `String` and `Language` to be applied
  */
+@available(*, deprecated, message: "Use TokenStream() instead")
 public class StreamRepresentation<N:Node,L:LexicalAnalyzer> : Sequence{
     /// The iterator type to use
     public typealias Iterator = NodeIterator<N>

--- a/Sources/OysterKit/Rules/ParserRules.swift
+++ b/Sources/OysterKit/Rules/ParserRules.swift
@@ -326,45 +326,45 @@ public indirect enum ParserRule : Rule, CustomStringConvertible{
         }
     }
     
+    public func instance(with token: Token?, andAnnotations annotations: RuleAnnotations?) -> Rule {
+        switch self{
+        case .terminal(let oldToken,let string, let oldAnnotations):
+            return ParserRule.terminal(produces: token ?? oldToken,string, annotations ?? oldAnnotations)
+        case .terminalFrom(let oldToken, let characterSet, let oldAnnotations):
+            return ParserRule.terminalFrom(produces: token ?? oldToken, characterSet, annotations ?? oldAnnotations)
+        case .terminalUntil(let oldToken,let string, let oldAnnotations):
+            return ParserRule.terminalUntil(produces: token ?? oldToken,string ,annotations ?? oldAnnotations)
+        case .terminalUntilOneOf(let oldToken, let characterSet, let oldAnnotations):
+            return ParserRule.terminalUntilOneOf(produces: token ?? oldToken, characterSet, annotations ?? oldAnnotations)
+        case .consume(let rule, let oldAnnotations):
+            return ParserRule.consume(rule, annotations ?? oldAnnotations)
+        case .repeated(let oldToken, let rule, let min, let limit, let oldAnnotations):
+            return ParserRule.repeated(produces: token ?? oldToken, rule, min: min, limit: limit, annotations ?? oldAnnotations)
+        case .optional(let oldToken, let rule, let oldAnnotations):
+            return ParserRule.optional(produces: token ?? oldToken, rule, annotations ?? oldAnnotations)
+        case .sequence(let oldToken, let rules, let oldAnnotations):
+            return ParserRule.sequence(produces: token ?? oldToken, rules, annotations ?? oldAnnotations)
+        case .oneOf(let oldToken, let rules, let oldAnnotations):
+            return ParserRule.oneOf(produces: token ?? oldToken, rules, annotations ?? oldAnnotations)
+        case .custom(let oldToken, let closure, let description, let oldAnnotations):
+            return ParserRule.custom(produces: oldToken, closure, description, annotations ?? oldAnnotations)
+        case .lookahead(let rule, let oldAnnotations):
+            return ParserRule.lookahead(rule, annotations ?? oldAnnotations)
+        case .not(let oldToken, let rule, let oldAnnotations):
+            return ParserRule.not(produces: token ?? oldToken, rule, annotations ?? oldAnnotations)
+        }
+
+    }
+    
     /// The annotations associated with the `Rule`
     public var annotations: RuleAnnotations{
-        get {
-            let definedAnnotations : RuleAnnotations?
-            switch self {
-            case .terminal(_, _, let annotations), .terminalFrom(_, _, let annotations), .terminalUntil(_, _, let annotations), .terminalUntilOneOf(_, _, let annotations), .consume(_, let annotations), .repeated(_, _, _, _, let annotations), .optional(_, _, let annotations), .sequence(_, _, let annotations), .oneOf(_, _, let annotations), .custom(_, _, _, let annotations), .lookahead(_, let annotations), .not(_, _, let annotations):
-                definedAnnotations = annotations
-            }
-            
-            return definedAnnotations ?? [:]
+        let definedAnnotations : RuleAnnotations?
+        switch self {
+        case .terminal(_, _, let annotations), .terminalFrom(_, _, let annotations), .terminalUntil(_, _, let annotations), .terminalUntilOneOf(_, _, let annotations), .consume(_, let annotations), .repeated(_, _, _, _, let annotations), .optional(_, _, let annotations), .sequence(_, _, let annotations), .oneOf(_, _, let annotations), .custom(_, _, _, let annotations), .lookahead(_, let annotations), .not(_, _, let annotations):
+            definedAnnotations = annotations
         }
-        set {
-            switch self{
-            case .terminal(let token,let string, _):
-                self = .terminal(produces: token,string ,newValue)
-            case .terminalFrom(let token, let characterSet, _):
-                self = .terminalFrom(produces: token, characterSet, newValue)
-            case .terminalUntil(let token,let string, _):
-                self = .terminalUntil(produces: token,string ,newValue)
-            case .terminalUntilOneOf(let token, let characterSet, _):
-                self = .terminalUntilOneOf(produces: token, characterSet, newValue)
-            case .consume(let rule, _):
-                self = .consume(rule, newValue)
-            case .repeated(let token, let rule, let min, let limit, _):
-                self = .repeated(produces: token, rule, min: min, limit: limit, newValue)
-            case .optional(let token, let rule, _):
-                self = .optional(produces: token, rule, newValue)
-            case .sequence(let token, let rules, _):
-                self = .sequence(produces: token, rules, newValue)
-            case .oneOf(let token, let rules, _):
-                self = .oneOf(produces: token, rules, newValue)
-            case .custom(let token, let closure, let description, _):
-                self = .custom(produces: token, closure, description, newValue)
-            case .lookahead(let rule, _):
-                self = .lookahead(rule, newValue)
-            case .not(let token, let rule, _):
-                self = .not(produces: token, rule, newValue)
-            }
-        }
+        
+        return definedAnnotations ?? [:]
     }
     
     /// A human readable description of the `Rule` almost in STLR

--- a/Sources/OysterKit/Rules/RecursiveRule.swift
+++ b/Sources/OysterKit/Rules/RecursiveRule.swift
@@ -27,7 +27,7 @@ import Foundation
 /**
  When a rule definition calls itself whilst evaluating itself (left hand recursion) you cannot create the rule directly as it will become caught in an infinite look (creating instances of itself, which create instances of itself etc until the stack is empty).  To avoid this a rule can use this wrapper to manage lazy initialization of itself. The recursive rule enables a reference to be added on the RHS, but the actual rule will not be initiialized until later, and this wrapper will then call that lazily initalized rule.
  */
-public class RecursiveRule : Rule{
+public class RecursiveRule : Rule, CustomStringConvertible{
     
     /// The initializer block responsible for creating the rule
     private var initBlock : (()->Rule)?
@@ -73,11 +73,18 @@ public class RecursiveRule : Rule{
             guard let  newRule = newValue else {
                 return
             }
+            _cachedDescription = "\(newRule)"
             initBlock = nil
             _matcher = newRule.match
             _produces = newRule.produces
         }
     }
+    
+    public var description: String{
+        return _cachedDescription ?? "Not set yet"
+    }
+    
+    var _cachedDescription : String?
     
     /// Delegated to the the surrogate rule
     public func match(with lexer: LexicalAnalyzer, for ir: IntermediateRepresentation) throws -> MatchResult {

--- a/Sources/OysterKit/Rules/RecursiveRule.swift
+++ b/Sources/OysterKit/Rules/RecursiveRule.swift
@@ -50,8 +50,8 @@ public class RecursiveRule : Rule, CustomStringConvertible{
     /// The surrogate token. This MUST use forced unwrapping as there must always be a token
     private var _produces    : Token
     
-    /// Always appears to be `nil` when read, but when set applies the matcher methods etc from the supplied rule to this so that the `RecursiveRule` behaves
-    /// exactly like the original rule.
+    /// The rule, which can be assigned at any point before actual parsing, to be used. When a new value is assigned to the rule a
+    /// new instance is created (calling ``instance(token, annotations)) with the token and annotations assigned at construction
     public var surrogateRule : Rule? {
         get{
             return rule

--- a/Sources/OysterKit/Rules/Rule.swift
+++ b/Sources/OysterKit/Rules/Rule.swift
@@ -81,6 +81,30 @@ public struct LabelledToken : Token, CustomStringConvertible {
     }
 }
 
+/// Allows easy creation of transient tokens
+public enum TransientToken : Token, CustomStringConvertible {
+    /// Just an anonymous but transient token
+    case anonymous
+    
+    /// A transient token with a name (often useful during custom AST construction)
+    case labelled(String)
+    
+    /// Always returns ``transientTokenValue``
+    public var rawValue : Int {
+        return transientTokenValue
+    }
+    
+    /// A human readable description of the token
+    public var description: String {
+        switch self {
+        case .anonymous:
+            return "transient"
+        case .labelled(let label):
+            return label
+        }
+    }
+}
+
 /**
  An extension to allow any `String` to be used as a `Token`.
  */

--- a/Sources/OysterKit/Rules/Rule.swift
+++ b/Sources/OysterKit/Rules/Rule.swift
@@ -370,14 +370,43 @@ public protocol Rule {
     var  produces : Token {get}
     
     /// The annotations on this rule
-    var  annotations : RuleAnnotations { get set }
+    var  annotations : RuleAnnotations { get }
     
     /// Returns the value of the specific `RuleAnnotationValue` identified by `annotation` if present
     subscript(annotation:RuleAnnotation)->RuleAnnotationValue? { get }
+    
+    /**
+     Create a new instance of the rule with the supplied annotations and token but otherwise exactly the same
+     
+     - Parameter token: The new ``Token`` or ``nil`` if the token should remain the same
+     - Parameter annotations: The new ``Annotations`` or ``nil`` if the annotations are unchanged
+     - Returns: A new instance of the ``Rule``. Callers should be aware that this may be a "deep" copy if the implementation is a value type
+    */
+    func instance(with token:Token?, andAnnotations annotations:RuleAnnotations?)->Rule
 }
 
 /// A set of standard properties and functions for all `Rule`s
 public extension Rule{
+
+    /**
+     Creates a new instance of the rule changing the ``Token`` produced
+     
+     - Parameter token: The new token to produce
+     - Returns: The new instance
+    */
+    public func instance(with token:Token)->Rule{
+        return instance(with: token, andAnnotations: nil)
+    }
+    
+    /**
+     Creates a new instance of the rule changing the ``RuleAnnotations`` associated with the rule
+     
+     - Parameter annotations: The new annotations to associate with the new instance
+     - Returns: The new instance
+     */
+    public func instance(with annotations: RuleAnnotations)->Rule{
+        return instance(with: nil, andAnnotations: annotations)
+    }
     
     /// The user specified (in an annotation) error associated with the rule
     public var error : String? {

--- a/Sources/OysterKit/Rules/Rule.swift
+++ b/Sources/OysterKit/Rules/Rule.swift
@@ -288,6 +288,27 @@ public enum RuleAnnotation : Hashable, CustomStringConvertible{
 /// A dictionary of annotations and their values
 public typealias RuleAnnotations = [RuleAnnotation : RuleAnnotationValue]
 
+/// Compares two ``RuleAnnotations``
+public func areEqual(lhs: RuleAnnotations, rhs: RuleAnnotations)->Bool{
+    func areEqual(lhs:RuleAnnotationValue, rhs:RuleAnnotationValue)->Bool{
+        return lhs.description == rhs.description
+    }
+    if lhs.count != rhs.count {
+        return false
+    }
+    
+    for tuple in lhs {
+        guard let rhsValue = rhs[tuple.key] else {
+            return false
+        }
+        if !areEqual(lhs: rhsValue, rhs: tuple.value) {
+            return false
+        }
+    }
+
+    return true
+}
+
 /// An extension for dictionaries of `RuleAnnotations`
 public extension Collection where Iterator.Element == (key:RuleAnnotation,value:RuleAnnotationValue){
     

--- a/Sources/OysterKit/Rules/Rule.swift
+++ b/Sources/OysterKit/Rules/Rule.swift
@@ -45,6 +45,43 @@ public protocol Token {
 }
 
 /**
+ Provides a convience static variable that returns a transient ``Token``
+ */
+public extension Token {
+    
+    /// A transient token
+    public static var transientToken : Token {
+        return transientTokenValue.token
+    }
+}
+
+/**
+ A generic ``Token`` implementation that is labelled (has an associated ``String`). The value is automatically generated
+ */
+public struct LabelledToken : Token, CustomStringConvertible {
+    /// The label for the token
+    private     let label : String
+    
+    /// The ``Int`` identifier of the Token. It is automatically generated
+    public      let rawValue : Int
+    
+    /**
+     Create a new token instance
+     
+     - Parameter label: The textual representation of the token
+    */
+    public init(withLabel label: String){
+        self.label = label
+        rawValue = label.hashValue
+    }
+    
+    /// A human readable representation of the token
+    public var description: String{
+        return label
+    }
+}
+
+/**
  An extension to allow any `String` to be used as a `Token`.
  */
 extension String : Token {

--- a/Sources/OysterKit/Rules/ScannerRules.swift
+++ b/Sources/OysterKit/Rules/ScannerRules.swift
@@ -117,18 +117,16 @@ public enum ScannerRule : Rule, CustomStringConvertible{
     /// Scanner rules cannot have annotations. All scanner rules can be modelled with
     /// full rules if annotations are needed
     public var annotations: RuleAnnotations{
-        get {
-            switch self {
-            case .oneOf(_,_, let annotations):
-                return annotations
-            }
+        switch self {
+        case .oneOf(_,_, let annotations):
+            return annotations
         }
-        
-        set {
-            switch self {
-            case .oneOf(let token, let strings, _):
-                self = .oneOf(token: token, strings, newValue)
-            }
+    }
+    
+    public func instance(with token: Token?, andAnnotations annotations: RuleAnnotations?) -> Rule {
+        switch self {
+        case .oneOf(let oldToken, let strings, let oldAnnotations):
+            return ScannerRule.oneOf(token: token ?? oldToken, strings, annotations ?? oldAnnotations)
         }
     }
 }

--- a/Sources/STLR/Generators/DynamicParserGenerator.swift
+++ b/Sources/STLR/Generators/DynamicParserGenerator.swift
@@ -151,7 +151,8 @@ fileprivate extension STLRIntermediateRepresentation.GrammarRule{
                         context.cachedRules[token.rawValue] = wrappedRule
                         return wrappedRule
                     } else {
-                        rule = rule.instance(with: token, andAnnotations: annotations)
+                        //Annotations on the identifier should override or add to those on the transient (or the same) token
+                        rule = rule.instance(with: token, andAnnotations: rule.annotations.merge(with: annotations))
                         context.cachedRules[token.rawValue] = rule
                         return rule
                     }

--- a/Sources/STLR/Generators/DynamicParserGenerator.swift
+++ b/Sources/STLR/Generators/DynamicParserGenerator.swift
@@ -268,8 +268,10 @@ fileprivate extension STLRIntermediateRepresentation.Modifier{
             return token
         case .not:
             return STLRIntermediateRepresentation.DynamicToken.init(rawValue: tokenRawValue, name: identifier ?? "!\(token)")
-        case .consume:
-            return STLRIntermediateRepresentation.DynamicToken.init(rawValue: tokenRawValue, name: identifier ?? "\(token)-")
+        case .transient:
+            return TransientToken.labelled(identifier ?? "\(token)~")
+        case .void:
+            return TransientToken.labelled(identifier ?? "\(token)-")
         case .zeroOrOne:
             return STLRIntermediateRepresentation.DynamicToken.init(rawValue: tokenRawValue, name: identifier ?? "\(token)?")
         case .oneOrMore:

--- a/Sources/STLR/Generators/DynamicParserGenerator.swift
+++ b/Sources/STLR/Generators/DynamicParserGenerator.swift
@@ -132,7 +132,7 @@ fileprivate extension STLRIntermediateRepresentation.GrammarRule{
             // wrapped, those annotations could be duplicated. What happens now is, they probably get lost.
             if let _ = identifier , leftHandRecursive {
                 
-                let rule = RecursiveRule(stubFor: token)
+                let rule = RecursiveRule(stubFor: token, with: annotations)
                 
                 context.cachedRules[token.rawValue] = rule
                 
@@ -321,9 +321,7 @@ extension STLRIntermediateRepresentation.Element{
             
             var finalRule = quantifier.rule(appliedTo: r, producing: quantifier.wrapped(token: identifier.token, annotations: mergedQuantifierAnnotations), quantifiersAnnotations: mergedQuantifierAnnotations)
             
-            finalRule.annotations = identifiersAnnotations.merge(with: finalRule.annotations)
-            
-            return finalRule
+            return finalRule.instance(with: identifiersAnnotations.merge(with: finalRule.annotations))
         }
     }
 

--- a/Sources/STLR/Generators/DynamicParserGenerator.swift
+++ b/Sources/STLR/Generators/DynamicParserGenerator.swift
@@ -121,11 +121,9 @@ fileprivate extension STLRIntermediateRepresentation.GrammarRule{
         let createToken = token ?? identifier?.token
 
         if let token = createToken{
-            if var cachedRule = context.cachedRules[token.rawValue]{
-                //Replace any cached annotations with those for the current instance
-//                cachedRule.annotations = annotations
-                
-                return cachedRule
+            if let cachedRule = context.cachedRules[token.rawValue]{
+                // Should fix Issue #39 - Lost identifier annotations
+                return cachedRule.instance(with: cachedRule.annotations.merge(with: annotations))
             }
             
             // For both of these code paths... the annotations get passed in to the generated expresion. If the rules are then

--- a/Sources/STLR/Generators/DynamicParserGenerator.swift
+++ b/Sources/STLR/Generators/DynamicParserGenerator.swift
@@ -129,17 +129,14 @@ fileprivate extension STLRIntermediateRepresentation.GrammarRule{
             // For both of these code paths... the annotations get passed in to the generated expresion. If the rules are then
             // wrapped, those annotations could be duplicated. What happens now is, they probably get lost.
             if let _ = identifier , leftHandRecursive {
-                
                 let rule = RecursiveRule(stubFor: token, with: annotations)
-                
                 context.cachedRules[token.rawValue] = rule
                 
                 guard let expressionsRule = expression?.rule(from: grammar, creating: token, inContext:context, annotations: [:]) else {
                     return nil
                 }
-                if expressionsRule.produces.rawValue != token.rawValue || !areEqual(lhs: expressionsRule.annotations,rhs: annotations){
-                    let wrappedRule = ParserRule.sequence(produces: token, [expressionsRule], annotations)
-                    rule.surrogateRule = wrappedRule
+                if expressionsRule.produces.rawValue != token.rawValue && expressionsRule.produces.rawValue != transientTokenValue{
+                    rule.surrogateRule = ParserRule.sequence(produces: token, [expressionsRule], annotations)
                 } else {
                     rule.surrogateRule = expressionsRule
                 }
@@ -148,7 +145,7 @@ fileprivate extension STLRIntermediateRepresentation.GrammarRule{
             } else {
                 if let rule = expression?.rule(from: grammar, creating: token, inContext:context, annotations: [:]){
                     //Sometimes the thing is folded completely flat
-                    if rule.produces.rawValue != token.rawValue || !areEqual(lhs: rule.annotations,rhs: annotations) {
+                    if rule.produces.rawValue != token.rawValue && rule.produces.rawValue != transientTokenValue {
                         let wrappedRule = ParserRule.sequence(produces: token, [rule], annotations)
                         context.cachedRules[token.rawValue] = wrappedRule
                         return wrappedRule
@@ -317,7 +314,7 @@ extension STLRIntermediateRepresentation.Element{
             }
             
             
-            var finalRule = quantifier.rule(appliedTo: r, producing: quantifier.wrapped(token: identifier.token, annotations: mergedQuantifierAnnotations), quantifiersAnnotations: mergedQuantifierAnnotations)
+            let finalRule = quantifier.rule(appliedTo: r, producing: quantifier.wrapped(token: identifier.token, annotations: mergedQuantifierAnnotations), quantifiersAnnotations: mergedQuantifierAnnotations)
             
             return finalRule.instance(with: identifiersAnnotations.merge(with: finalRule.annotations))
         }

--- a/Sources/STLR/Generators/SwiftGenerator.swift
+++ b/Sources/STLR/Generators/SwiftGenerator.swift
@@ -442,8 +442,13 @@ internal extension STLRIntermediateRepresentation.Modifier{
             return ""
         case .not:
             return ".not(producing: T.\(token)\(annotations?.swiftNthParameter ?? ""))"
-        case .consume:
-            return ".consume(\(annotations?.swiftDictionary ?? ""))"
+        case .void:
+            let finalAnnotations = annotations?.merge(with: [STLRIntermediateRepresentation.ElementAnnotationInstance.init(STLRIntermediateRepresentation.ElementAnnotation.void)])
+            return """
+                .instance(with: TransientToken.labelled("\(token)-"), andAnnotations: \(finalAnnotations?.swiftNthParameter ?? ""))
+            """
+        case .transient:
+            return ".instance(with: TransientToken.anonymous, andAnnotations: \(annotations?.swiftNthParameter ?? ""))"
         case .zeroOrOne:
             return ".optional(producing: T.\(token)\(annotations?.swiftNthParameter ?? ""))"
         case .zeroOrMore:

--- a/Sources/STLR/STLR.swift
+++ b/Sources/STLR/STLR.swift
@@ -32,7 +32,7 @@ enum STLR : Int, Token {
 		case .multilineComment:
 			guard let cachedRule = STLR.leftHandRecursiveRules[self.rawValue] else {
 				// Create recursive shell
-				let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: self, with: annotations.isEmpty ? [ : ] : annotations)
 				STLR.leftHandRecursiveRules[self.rawValue] = recursiveRule
 				// Create the rule we would normally generate
 				let rule = [
@@ -42,7 +42,7 @@ enum STLR : Int, Token {
 									"*/".terminal(token: T._transient).not(producing: T._transient),
 									].oneOf(token: T._transient).repeated(min: 0, producing: T._transient),
 					"*/".terminal(token: T._transient),
-					].sequence(token: T.multilineComment, annotations: annotations.isEmpty ? [ : ] : annotations)
+                    ].sequence(token: T._transient, annotations: [:])
 				recursiveRule.surrogateRule = rule
 				return recursiveRule
 			}
@@ -193,7 +193,7 @@ enum STLR : Int, Token {
 		case .group:
 			guard let cachedRule = STLR.leftHandRecursiveRules[self.rawValue] else {
 				// Create recursive shell
-				let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: self, with: annotations.isEmpty ? [ : ] : annotations)
 				STLR.leftHandRecursiveRules[self.rawValue] = recursiveRule
 				// Create the rule we would normally generate
 				let rule = [
@@ -202,7 +202,7 @@ enum STLR : Int, Token {
 					T.expression._rule(),
 					T.whitespace._rule([RuleAnnotation.void : RuleAnnotationValue.set]).repeated(min: 0, producing: T._transient),
 					")".terminal(token: T._transient, annotations: [RuleAnnotation.error : RuleAnnotationValue.string("Expected ')'")]),
-					].sequence(token: T.group, annotations: annotations.isEmpty ? [ : ] : annotations)
+                    ].sequence(token: T._transient, annotations: [:])
 				recursiveRule.surrogateRule = rule
 				return recursiveRule
 			}
@@ -217,7 +217,7 @@ enum STLR : Int, Token {
 		case .element:
 			guard let cachedRule = STLR.leftHandRecursiveRules[self.rawValue] else {
 				// Create recursive shell
-				let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: T.element, with: annotations.isEmpty ? [ : ] : annotations )
 				STLR.leftHandRecursiveRules[self.rawValue] = recursiveRule
 				// Create the rule we would normally generate
 				let rule = [
@@ -233,7 +233,7 @@ enum STLR : Int, Token {
 									T.identifier._rule(),
 									].oneOf(token: T._transient),
 					T.quantifier._rule().optional(producing: T._transient),
-					].sequence(token: T.element, annotations: annotations.isEmpty ? [ : ] : annotations)
+                    ].sequence(token: T._transient, annotations: [ : ])
 				recursiveRule.surrogateRule = rule
 				return recursiveRule
 			}
@@ -262,7 +262,7 @@ enum STLR : Int, Token {
 		case .choice:
 			guard let cachedRule = STLR.leftHandRecursiveRules[self.rawValue] else {
 				// Create recursive shell
-				let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: self, with: annotations.isEmpty ? [ : ] : annotations)
 				STLR.leftHandRecursiveRules[self.rawValue] = recursiveRule
 				// Create the rule we would normally generate
 				let rule = [
@@ -271,7 +271,7 @@ enum STLR : Int, Token {
 									T.or._rule([RuleAnnotation.void : RuleAnnotationValue.set]),
 									T.element._rule([RuleAnnotation.error : RuleAnnotationValue.string("Expected terminal, identifier, or group")]),
 									].sequence(token: T._transient).repeated(min: 1, producing: T._transient),
-					].sequence(token: T.choice, annotations: annotations.isEmpty ? [ : ] : annotations)
+                    ].sequence(token: T._transient, annotations: [ : ])
 				recursiveRule.surrogateRule = rule
 				return recursiveRule
 			}
@@ -288,7 +288,7 @@ enum STLR : Int, Token {
 		case .sequence:
 			guard let cachedRule = STLR.leftHandRecursiveRules[self.rawValue] else {
 				// Create recursive shell
-				let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: self, with: annotations.isEmpty ? [ : ] : annotations)
 				STLR.leftHandRecursiveRules[self.rawValue] = recursiveRule
 				// Create the rule we would normally generate
 				let rule = [
@@ -298,7 +298,7 @@ enum STLR : Int, Token {
 									T.notNewRule._rule().lookahead(),
 									T.element._rule([RuleAnnotation.error : RuleAnnotationValue.string("Expected terminal, identifier, or group")]),
 									].sequence(token: T._transient).repeated(min: 1, producing: T._transient),
-					].sequence(token: T.sequence, annotations: annotations.isEmpty ? [ : ] : annotations)
+                    ].sequence(token: T._transient, annotations: [ : ])
 				recursiveRule.surrogateRule = rule
 				return recursiveRule
 			}
@@ -307,14 +307,14 @@ enum STLR : Int, Token {
 		case .expression:
 			guard let cachedRule = STLR.leftHandRecursiveRules[self.rawValue] else {
 				// Create recursive shell
-				let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: self, with: annotations)
 				STLR.leftHandRecursiveRules[self.rawValue] = recursiveRule
 				// Create the rule we would normally generate
 				let rule = [
 					T.choice._rule(),
 					T.sequence._rule(),
 					T.element._rule(),
-					].oneOf(token: T.expression, annotations: annotations)
+                    ].oneOf(token: T._transient, annotations: [:])
 				recursiveRule.surrogateRule = rule
 				return recursiveRule
 			}

--- a/Tests/OysterKitTests/HomegenousASTTests.swift
+++ b/Tests/OysterKitTests/HomegenousASTTests.swift
@@ -112,14 +112,14 @@ enum XMLGenerated : Int, Token {
         case .nestingTag:
             guard let cachedRule = XMLGenerated.leftHandRecursiveRules[self.rawValue] else {
                 // Create recursive shell
-                let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: self, with: annotations.isEmpty ? [ : ] : annotations)
                 XMLGenerated.leftHandRecursiveRules[self.rawValue] = recursiveRule
                 // Create the rule we would normally generate
                 let rule = [
                     T.openTag._rule(),
                     T.contents._rule().repeated(min: 0, producing: T._transient),
                     T.closeTag._rule([RuleAnnotation.error : RuleAnnotationValue.string("Expected closing tag")]),
-                    ].sequence(token: T.nestingTag, annotations: annotations.isEmpty ? [ : ] : annotations)
+                    ].sequence(token: T.nestingTag, annotations: [ : ])
                 recursiveRule.surrogateRule = rule
                 return recursiveRule
             }
@@ -128,13 +128,13 @@ enum XMLGenerated : Int, Token {
         case .tag:
             guard let cachedRule = XMLGenerated.leftHandRecursiveRules[self.rawValue] else {
                 // Create recursive shell
-                let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: self, with: annotations)
                 XMLGenerated.leftHandRecursiveRules[self.rawValue] = recursiveRule
                 // Create the rule we would normally generate
                 let rule = [
                     T.nestingTag._rule(),
                     T.inlineTag._rule(),
-                    ].oneOf(token: T.tag, annotations: annotations)
+                    ].oneOf(token: T._transient, annotations: [:])
                 recursiveRule.surrogateRule = rule
                 return recursiveRule
             }
@@ -143,13 +143,13 @@ enum XMLGenerated : Int, Token {
         case .contents:
             guard let cachedRule = XMLGenerated.leftHandRecursiveRules[self.rawValue] else {
                 // Create recursive shell
-                let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: self, with: annotations)
                 XMLGenerated.leftHandRecursiveRules[self.rawValue] = recursiveRule
                 // Create the rule we would normally generate
                 let rule = [
                     T.data._rule(),
                     T.tag._rule(),
-                    ].oneOf(token: T.contents, annotations: annotations)
+                    ].oneOf(token: T._transient, annotations: [:])
                 recursiveRule.surrogateRule = rule
                 return recursiveRule
             }

--- a/Tests/OysterKitTests/RuleTests.swift
+++ b/Tests/OysterKitTests/RuleTests.swift
@@ -1,0 +1,19 @@
+//
+//  RuleTests.swift
+//  OysterKitTests
+//
+//  Created by Nigel Hughes on 03/02/2018.
+//
+
+import XCTest
+
+class RuleTests: XCTestCase {
+
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+
+}

--- a/Tests/STLRTests/DynamicGeneratorTest.swift
+++ b/Tests/STLRTests/DynamicGeneratorTest.swift
@@ -57,12 +57,16 @@ class DynamicGeneratorTest: XCTestCase {
         }
         
         if let tree = try? AbstractSyntaxTreeConstructor().build(">", using: dynamicLangauage)  {
+            print(tree.description)
             XCTAssertTrue("\(tree.token)" == "arrows", "Root node should be arrows")
             XCTAssertTrue(tree.isSet(annotation: RuleAnnotation.custom(label: "forArrows")))
             guard let arrowNode = tree.nodeAtPath(["arrow"]) else {
                 XCTFail("Arrow is not a child of arrows"); return
             }
             XCTAssertTrue(arrowNode.isSet(annotation: RuleAnnotation.custom(label: "forArrow")))
+            XCTAssertEqual(tree.annotations.count, 1)
+            XCTAssertEqual(arrowNode.annotations.count, 1)
+
         } else {
             XCTFail("Could not parse the test source using the generated language"); return
         }
@@ -82,10 +86,12 @@ class DynamicGeneratorTest: XCTestCase {
             print(tree.description)
             XCTAssertTrue("\(tree.token)" == "arrows", "Root node should be arrows")
             XCTAssertTrue(tree.isSet(annotation: RuleAnnotation.custom(label: "forArrows")))
+            XCTAssertEqual(tree.annotations.count, 1)
             guard let arrowNode = tree.nodeAtPath(["arrow"]) else {
                 XCTFail("Arrow is not a child of arrows"); return
             }
             XCTAssertTrue(arrowNode.isSet(annotation: RuleAnnotation.custom(label: "forArrow")))
+            XCTAssertEqual(arrowNode.annotations.count, 1)
         } else {
             XCTFail("Could not parse the test source using the generated language"); return
         }
@@ -102,7 +108,7 @@ class DynamicGeneratorTest: XCTestCase {
             XCTFail("Could not compile the grammar under test"); return
         }
         
-        if let tree = try? AbstractSyntaxTreeConstructor().build(">>", using: dynamicLangauage)  {
+        if let tree = try? AbstractSyntaxTreeConstructor().build(">", using: dynamicLangauage)  {
             print(tree.description)
             XCTAssertTrue("\(tree.token)" == "arrows", "Root node should be arrows")
             XCTAssertTrue(tree.isSet(annotation: RuleAnnotation.custom(label: "forArrows")))
@@ -110,6 +116,9 @@ class DynamicGeneratorTest: XCTestCase {
                 XCTFail("Arrow is not a child of arrows"); return
             }
             XCTAssertTrue(arrowNode.isSet(annotation: RuleAnnotation.custom(label: "forArrow")))
+            XCTAssertEqual(tree.annotations.count, 1)
+            XCTAssertEqual(arrowNode.annotations.count, 1)
+
         } else {
             XCTFail("Could not parse the test source using the generated language"); return
         }
@@ -133,6 +142,9 @@ class DynamicGeneratorTest: XCTestCase {
                 XCTFail("Arrow is not a child of arrows"); return
             }
             XCTAssertTrue(arrowNode.isSet(annotation: RuleAnnotation.custom(label: "forArrow")))
+            XCTAssertEqual(tree.annotations.count, 1)
+            XCTAssertEqual(arrowNode.annotations.count, 1)
+
         } else {
             XCTFail("Could not parse the test source using the generated language"); return
         }

--- a/Tests/STLRTests/DynamicGeneratorTest.swift
+++ b/Tests/STLRTests/DynamicGeneratorTest.swift
@@ -1,10 +1,26 @@
+//    Copyright (c) 2014, RED When Excited
+//    All rights reserved.
 //
-//  DynamicGeneratorTest.swift
-//  OysterKit
+//    Redistribution and use in source and binary forms, with or without
+//    modification, are permitted provided that the following conditions are met:
 //
-//  
-//  Copyright © 2016 RED When Excited. All rights reserved.
+//    * Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
 //
+//    * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+//    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+//    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+//    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import XCTest
 @testable import OysterKit

--- a/Tests/STLRTests/GrammarTest.swift
+++ b/Tests/STLRTests/GrammarTest.swift
@@ -229,8 +229,8 @@ class GrammarTest: XCTestCase {
     }
     
     func testQuantifiersNotAddedToIdentifierNames(){
-        source.add(line: "whitespace = ws+")
         source.add(line: "ws = .whitespaces")
+        source.add(line: "whitespace = ws+")
         source.add(line: "word = .letters+")
         
         let stlr = STLRParser(source: source)
@@ -238,8 +238,8 @@ class GrammarTest: XCTestCase {
         let ast = stlr.ast
         
         XCTAssert(ast.rules.count == 3, "Found \(ast.rules.count) rules when there should be 1")
-        XCTAssert(ast.rules[0].identifier?.name ?? "fail" == "whitespace")
-        XCTAssert(ast.rules[1].identifier?.name ?? "fail" == "ws")
+        XCTAssert(ast.rules[0].identifier?.name ?? "fail" == "ws")
+        XCTAssert(ast.rules[1].identifier?.name ?? "fail" == "whitespace")
         XCTAssert(ast.rules[2].identifier?.name ?? "fail" == "word")
         
         do {

--- a/Tests/STLRTests/GrammarTest.swift
+++ b/Tests/STLRTests/GrammarTest.swift
@@ -100,6 +100,7 @@ class GrammarTest: XCTestCase {
             throw CheckError.checkFailed(reason: "Language did not compile")
         }
         
+        
         let stream : AnySequence<HomogenousNode> = language.stream(source: source)
         
         let iterator = stream.makeIterator()
@@ -185,21 +186,21 @@ class GrammarTest: XCTestCase {
     }
     
     func testRecursiveRule(){
-        source.add(line: "xy = x \"y\"")
-        source.add(line: "justX = x")
         source.add(line: "x = \"x\"")
+        source.add(line: "justX = x")
+        source.add(line: "xy = x \"y\"")
         
         let stlr = STLRParser(source: source)
         
         let ast = stlr.ast
         
         XCTAssert(ast.rules.count == 3, "Found \(ast.rules.count) rules when there should be 1")
-        XCTAssert(ast.rules[0].identifier?.name ?? "fail" == "xy")
+        XCTAssert(ast.rules[0].identifier?.name ?? "fail" == "x")
         XCTAssert(ast.rules[1].identifier?.name ?? "fail" == "justX")
-        XCTAssert(ast.rules[2].identifier?.name ?? "fail" == "x")
+        XCTAssert(ast.rules[2].identifier?.name ?? "fail" == "xy")
         
         do {
-            try checkGeneratedLanguage(language: ast.runtimeLanguage, on: "xyx", expecting: [1,3])
+            try checkGeneratedLanguage(language: ast.runtimeLanguage, on: "xyx", expecting: [3,2])
         } catch (let error) {
             XCTFail("\(error)")
         }
@@ -228,8 +229,8 @@ class GrammarTest: XCTestCase {
     }
     
     func testQuantifiersNotAddedToIdentifierNames(){
-        source.add(line: "ws = .whitespaces")
         source.add(line: "whitespace = ws+")
+        source.add(line: "ws = .whitespaces")
         source.add(line: "word = .letters+")
         
         let stlr = STLRParser(source: source)
@@ -237,8 +238,8 @@ class GrammarTest: XCTestCase {
         let ast = stlr.ast
         
         XCTAssert(ast.rules.count == 3, "Found \(ast.rules.count) rules when there should be 1")
-        XCTAssert(ast.rules[0].identifier?.name ?? "fail" == "ws")
-        XCTAssert(ast.rules[1].identifier?.name ?? "fail" == "whitespace")
+        XCTAssert(ast.rules[0].identifier?.name ?? "fail" == "whitespace")
+        XCTAssert(ast.rules[1].identifier?.name ?? "fail" == "ws")
         XCTAssert(ast.rules[2].identifier?.name ?? "fail" == "word")
         
         do {
@@ -269,7 +270,10 @@ class GrammarTest: XCTestCase {
 
     
     func testShallowFolding(){
-        let source = "space = .whitespaces \nspaces = space+\n"
+        let source = """
+            space = .whitespaces
+            spaces = space+
+            """
         
         let testString = "    "
         

--- a/Tests/STLRTests/HierarchyTests.swift
+++ b/Tests/STLRTests/HierarchyTests.swift
@@ -1,0 +1,34 @@
+//
+//  HierarchyTests.swift
+//  STLRTests
+//
+//  Created by Nigel Hughes on 31/01/2018.
+//
+
+import XCTest
+
+class HierarchyTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Tests/STLRTests/HierarchyTests.swift
+++ b/Tests/STLRTests/HierarchyTests.swift
@@ -1,9 +1,26 @@
+//    Copyright (c) 2014, RED When Excited
+//    All rights reserved.
 //
-//  HierarchyTests.swift
-//  STLRTests
+//    Redistribution and use in source and binary forms, with or without
+//    modification, are permitted provided that the following conditions are met:
 //
-//  Created by Nigel Hughes on 31/01/2018.
+//    * Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
 //
+//    * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+//    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+//    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+//    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import XCTest
 import OysterKit
@@ -86,7 +103,6 @@ xml             = tag
 //
 // Generated: 2018-01-31 23:30:11 +0000
 //
-import Cocoa
 import OysterKit
 
 //

--- a/Tests/STLRTests/HierarchyTests.swift
+++ b/Tests/STLRTests/HierarchyTests.swift
@@ -12,6 +12,8 @@ import STLR
 class HierarchyTests: XCTestCase {
 
     func testExample() {
+        // This needs to be integrated fully
+        return
         guard let grammarSource = try? String(contentsOfFile: "/Volumes/Personal/SPM/XMLDecoder/XML.stlr") else {
             fatalError("Could not load grammar")
         }

--- a/Tests/STLRTests/HierarchyTests.swift
+++ b/Tests/STLRTests/HierarchyTests.swift
@@ -191,14 +191,14 @@ enum XML : Int, Token {
         case .nestingTag:
             guard let cachedRule = XML.leftHandRecursiveRules[self.rawValue] else {
                 // Create recursive shell
-                let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: self, with: annotations.isEmpty ? [ : ] : annotations)
                 XML.leftHandRecursiveRules[self.rawValue] = recursiveRule
                 // Create the rule we would normally generate
                 let rule = [
                     T.openTag._rule([RuleAnnotation.transient : RuleAnnotationValue.set]),
                     T.contents._rule(),
                     T.closeTag._rule([RuleAnnotation.void : RuleAnnotationValue.set,RuleAnnotation.error : RuleAnnotationValue.string("Expected closing tag")]),
-                    ].sequence(token: T.nestingTag, annotations: annotations.isEmpty ? [ : ] : annotations)
+                    ].sequence(token: T._transient, annotations: [:])
                 recursiveRule.surrogateRule = rule
                 return recursiveRule
             }
@@ -207,13 +207,13 @@ enum XML : Int, Token {
         case .tag:
             guard let cachedRule = XML.leftHandRecursiveRules[self.rawValue] else {
                 // Create recursive shell
-                let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: self, with: annotations)
                 XML.leftHandRecursiveRules[self.rawValue] = recursiveRule
                 // Create the rule we would normally generate
                 let rule = [
                     T.nestingTag._rule([RuleAnnotation.transient : RuleAnnotationValue.set]),
                     T.inlineTag._rule([RuleAnnotation.transient : RuleAnnotationValue.set]),
-                    ].oneOf(token: T.tag, annotations: annotations)
+                    ].oneOf(token: T._transient, annotations: [:])
                 recursiveRule.surrogateRule = rule
                 return recursiveRule
             }
@@ -222,13 +222,13 @@ enum XML : Int, Token {
         case .content:
             guard let cachedRule = XML.leftHandRecursiveRules[self.rawValue] else {
                 // Create recursive shell
-                let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: self, with: annotations)
                 XML.leftHandRecursiveRules[self.rawValue] = recursiveRule
                 // Create the rule we would normally generate
                 let rule = [
                     T.data._rule(),
                     T.tag._rule(),
-                    ].oneOf(token: T._transient, annotations: annotations).repeated(min: 0, producing: T.content, annotations: annotations)
+                    ].oneOf(token: T._transient, annotations: annotations).repeated(min: 0, producing: T._transient, annotations: [:])
                 recursiveRule.surrogateRule = rule
                 return recursiveRule
             }
@@ -237,7 +237,7 @@ enum XML : Int, Token {
         case .contents:
             guard let cachedRule = XML.leftHandRecursiveRules[self.rawValue] else {
                 // Create recursive shell
-                let recursiveRule = RecursiveRule()
+                let recursiveRule = RecursiveRule(stubFor: self, with: [:])
                 XML.leftHandRecursiveRules[self.rawValue] = recursiveRule
                 // Create the rule we would normally generate
                 let rule = [T.content._rule()].sequence(token: self)

--- a/Tests/STLRTests/HierarchyTests.swift
+++ b/Tests/STLRTests/HierarchyTests.swift
@@ -6,29 +6,263 @@
 //
 
 import XCTest
+import OysterKit
+import STLR
 
 class HierarchyTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    func testExample() {
+        guard let grammarSource = try? String(contentsOfFile: "/Volumes/Personal/SPM/XMLDecoder/XML.stlr") else {
+            fatalError("Could not load grammar")
+        }
+        
+        guard let xmlLanguage = STLRParser.init(source: grammarSource).ast.runtimeLanguage else {
+            fatalError("Could not create language")
+        }
+        
+        let xmlSource = """
+<message subject='Hello, OysterKit!' priority="High">
+    It's really <i>good</i> to meet you,
+    <p />
+    I hope you are settling in OK, let me know if you need anything.
+    <p />
+    Phatom Testers
+</message>
+"""
+        for rule in xmlLanguage.grammar {
+            print("Rule:\n\t\(rule)")
+        }
+
+        do {
+            let tree = try AbstractSyntaxTreeConstructor().build(xmlSource, using: XML.generatedLanguage)
+            print(tree.description)
+        } catch {
+            print(error)
+            XCTFail("Could not parse source"); return
+        }
+        
+//        print(STLRParser.init(source: grammarSource).ast.swift(grammar: "XML")!)
     }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
+    let xmlStlr = """
+//
+// XML Grammar
+//
 
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
+// Scanner Rules
+@void ws        = .whitespacesAndNewlines
+identifier      = .letters (.letters | ("-" .letters))*
+singleQuote     = "'"
+doubleQuote     = "\""
 
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
+value           =       (-singleQuote !singleQuote* @error("Expected closing '")  -singleQuote) |
+                        (-doubleQuote !doubleQuote* @error("Expected closing \"") -doubleQuote)
+
+attribute       = ws+ identifier (ws* -"=" ws* value)?
+attributes      = attribute+
+
+data            = !"<"+
+
+openTag         = ws* -"<"  identifier (attributes | ws*) -">"
+@void
+closeTag        = ws* -"</" identifier ws* -">"
+inlineTag       = ws* -"<"  identifier (attribute+ | ws*) -"/>"
+nestingTag      = @transient openTag contents @error("Expected closing tag") closeTag
+
+// Grammar Rules
+tag             = @transient nestingTag | @transient inlineTag
+contents        = @token("content") (data | tag)*
+
+// AST Root
+xml             = tag
+"""
 
 }
+
+//
+// STLR Generated Swift File
+//
+// Generated: 2018-01-31 23:30:11 +0000
+//
+import Cocoa
+import OysterKit
+
+//
+// XML Parser
+//
+enum XML : Int, Token {
+    
+    // Convenience alias
+    private typealias T = XML
+    
+    case _transient = -1, `ws`, `identifier`, `singleQuote`, `doubleQuote`, `value`, `attribute`, `attributes`, `data`, `openTag`, `closeTag`, `inlineTag`, `nestingTag`, `tag`, `content`, `contents`, `xml`
+    
+    func _rule(_ annotations: RuleAnnotations = [ : ])->Rule {
+        switch self {
+        case ._transient:
+            return CharacterSet(charactersIn: "").terminal(token: T._transient)
+        // ws
+        case .ws:
+            return CharacterSet.whitespacesAndNewlines.terminal(token: T.ws, annotations: annotations.isEmpty ? [RuleAnnotation.void : RuleAnnotationValue.set] : annotations)
+        // identifier
+        case .identifier:
+            return [
+                CharacterSet.letters.terminal(token: T._transient),
+                [
+                    CharacterSet.letters.terminal(token: T._transient),
+                    [
+                        "-".terminal(token: T._transient),
+                        CharacterSet.letters.terminal(token: T._transient),
+                        ].sequence(token: T._transient),
+                    ].oneOf(token: T._transient).repeated(min: 0, producing: T._transient),
+                ].sequence(token: T.identifier, annotations: annotations.isEmpty ? [ : ] : annotations)
+        // singleQuote
+        case .singleQuote:
+            return "'".terminal(token: T.singleQuote, annotations: annotations)
+        // doubleQuote
+        case .doubleQuote:
+            return "\"".terminal(token: T.doubleQuote, annotations: annotations)
+        // value
+        case .value:
+            return [
+                [
+                    T.singleQuote._rule([RuleAnnotation.transient : RuleAnnotationValue.set]),
+                    T.singleQuote._rule().not(producing: T._transient).repeated(min: 0, producing: T._transient),
+                    T.singleQuote._rule([RuleAnnotation.error : RuleAnnotationValue.string("Expected closing '"),RuleAnnotation.transient : RuleAnnotationValue.set]),
+                    ].sequence(token: T._transient),
+                [
+                    T.doubleQuote._rule([RuleAnnotation.transient : RuleAnnotationValue.set]),
+                    T.doubleQuote._rule().not(producing: T._transient).repeated(min: 0, producing: T._transient),
+                    T.doubleQuote._rule([RuleAnnotation.error : RuleAnnotationValue.string("Expected closing \""),RuleAnnotation.transient : RuleAnnotationValue.set]),
+                    ].sequence(token: T._transient),
+                ].oneOf(token: T.value, annotations: annotations)
+        // attribute
+        case .attribute:
+            return [
+                T.ws._rule([RuleAnnotation.void : RuleAnnotationValue.set]).repeated(min: 1, producing: T._transient),
+                T.identifier._rule(),
+                [
+                    T.ws._rule([RuleAnnotation.void : RuleAnnotationValue.set]).repeated(min: 0, producing: T._transient),
+                    "=".terminal(token: T._transient, annotations: [RuleAnnotation.transient : RuleAnnotationValue.set]),
+                    T.ws._rule([RuleAnnotation.void : RuleAnnotationValue.set]).repeated(min: 0, producing: T._transient),
+                    T.value._rule(),
+                    ].sequence(token: T._transient).optional(producing: T._transient),
+                ].sequence(token: T.attribute, annotations: annotations.isEmpty ? [ : ] : annotations)
+        // attributes
+        case .attributes:
+            return T.attribute._rule().repeated(min: 1, producing: T.attributes, annotations: annotations)
+        // data
+        case .data:
+            return "<".terminal(token: T._transient, annotations: annotations).not(producing: T._transient, annotations: annotations).repeated(min: 1, producing: T.data, annotations: annotations)
+        // openTag
+        case .openTag:
+            return [
+                T.ws._rule([RuleAnnotation.void : RuleAnnotationValue.set]).repeated(min: 0, producing: T._transient),
+                "<".terminal(token: T._transient, annotations: [RuleAnnotation.transient : RuleAnnotationValue.set]),
+                T.identifier._rule(),
+                [
+                    T.attributes._rule(),
+                    T.ws._rule([RuleAnnotation.void : RuleAnnotationValue.set]).repeated(min: 0, producing: T._transient),
+                    ].oneOf(token: T._transient),
+                ">".terminal(token: T._transient, annotations: [RuleAnnotation.transient : RuleAnnotationValue.set]),
+                ].sequence(token: T.openTag, annotations: annotations.isEmpty ? [ : ] : annotations)
+        // closeTag
+        case .closeTag:
+            return [
+                T.ws._rule([RuleAnnotation.void : RuleAnnotationValue.set]).repeated(min: 0, producing: T._transient),
+                "</".terminal(token: T._transient, annotations: [RuleAnnotation.transient : RuleAnnotationValue.set]),
+                T.identifier._rule(),
+                T.ws._rule([RuleAnnotation.void : RuleAnnotationValue.set]).repeated(min: 0, producing: T._transient),
+                ">".terminal(token: T._transient, annotations: [RuleAnnotation.transient : RuleAnnotationValue.set]),
+                ].sequence(token: T.closeTag, annotations: annotations.isEmpty ? [RuleAnnotation.void : RuleAnnotationValue.set] : annotations)
+        // inlineTag
+        case .inlineTag:
+            return [
+                T.ws._rule([RuleAnnotation.void : RuleAnnotationValue.set]).repeated(min: 0, producing: T._transient),
+                "<".terminal(token: T._transient, annotations: [RuleAnnotation.transient : RuleAnnotationValue.set]),
+                T.identifier._rule(),
+                [
+                    T.attribute._rule().repeated(min: 1, producing: T._transient),
+                    T.ws._rule([RuleAnnotation.void : RuleAnnotationValue.set]).repeated(min: 0, producing: T._transient),
+                    ].oneOf(token: T._transient),
+                "/>".terminal(token: T._transient, annotations: [RuleAnnotation.transient : RuleAnnotationValue.set]),
+                ].sequence(token: T.inlineTag, annotations: annotations.isEmpty ? [ : ] : annotations)
+        // nestingTag
+        case .nestingTag:
+            guard let cachedRule = XML.leftHandRecursiveRules[self.rawValue] else {
+                // Create recursive shell
+                let recursiveRule = RecursiveRule()
+                XML.leftHandRecursiveRules[self.rawValue] = recursiveRule
+                // Create the rule we would normally generate
+                let rule = [
+                    T.openTag._rule([RuleAnnotation.transient : RuleAnnotationValue.set]),
+                    T.contents._rule(),
+                    T.closeTag._rule([RuleAnnotation.void : RuleAnnotationValue.set,RuleAnnotation.error : RuleAnnotationValue.string("Expected closing tag")]),
+                    ].sequence(token: T.nestingTag, annotations: annotations.isEmpty ? [ : ] : annotations)
+                recursiveRule.surrogateRule = rule
+                return recursiveRule
+            }
+            return cachedRule
+        // tag
+        case .tag:
+            guard let cachedRule = XML.leftHandRecursiveRules[self.rawValue] else {
+                // Create recursive shell
+                let recursiveRule = RecursiveRule()
+                XML.leftHandRecursiveRules[self.rawValue] = recursiveRule
+                // Create the rule we would normally generate
+                let rule = [
+                    T.nestingTag._rule([RuleAnnotation.transient : RuleAnnotationValue.set]),
+                    T.inlineTag._rule([RuleAnnotation.transient : RuleAnnotationValue.set]),
+                    ].oneOf(token: T.tag, annotations: annotations)
+                recursiveRule.surrogateRule = rule
+                return recursiveRule
+            }
+            return cachedRule
+        // content
+        case .content:
+            guard let cachedRule = XML.leftHandRecursiveRules[self.rawValue] else {
+                // Create recursive shell
+                let recursiveRule = RecursiveRule()
+                XML.leftHandRecursiveRules[self.rawValue] = recursiveRule
+                // Create the rule we would normally generate
+                let rule = [
+                    T.data._rule(),
+                    T.tag._rule(),
+                    ].oneOf(token: T._transient, annotations: annotations).repeated(min: 0, producing: T.content, annotations: annotations)
+                recursiveRule.surrogateRule = rule
+                return recursiveRule
+            }
+            return cachedRule
+        // contents
+        case .contents:
+            guard let cachedRule = XML.leftHandRecursiveRules[self.rawValue] else {
+                // Create recursive shell
+                let recursiveRule = RecursiveRule()
+                XML.leftHandRecursiveRules[self.rawValue] = recursiveRule
+                // Create the rule we would normally generate
+                let rule = [T.content._rule()].sequence(token: self)
+                recursiveRule.surrogateRule = rule
+                return recursiveRule
+            }
+            return cachedRule
+        // xml
+        case .xml:
+            return [T.tag._rule()].sequence(token: self)
+        }
+    }
+    
+    
+    // Cache for left-hand recursive rules
+    private static var leftHandRecursiveRules = [ Int : Rule ]()
+    
+    // Create a language that can be used for parsing etc
+    public static var generatedLanguage : Parser {
+        return Parser(grammar: [T.xml._rule()])
+    }
+    
+    // Convient way to apply your grammar to a string
+    public static func parse(source: String) -> DefaultHeterogeneousAST {
+        return XML.generatedLanguage.build(source: source)
+    }
+}
+

--- a/Tests/STLRTests/OptimizersTest.swift
+++ b/Tests/STLRTests/OptimizersTest.swift
@@ -24,8 +24,10 @@ class OptimizersTest: GrammarTest {
     }
     
     func testAttributePreservationOnInline(){
-        source.add(line: "x = @error(\"Expected X\")\"x\"")
-        source.add(line: "xyz = x \"y\" \"z\"")
+        source += """
+            x = @error("Expected X") "x"
+            xyz = x "y" "z"
+        """
 
         STLRIntermediateRepresentation.register(optimizer: InlineIdentifierOptimization())
         let parser = STLRParser(source: source)

--- a/Tests/STLRTests/STLRTests.swift
+++ b/Tests/STLRTests/STLRTests.swift
@@ -69,18 +69,16 @@ class STLRTest: XCTestCase {
         print(stlr.ast.swift(grammar: "Test")!)
         
         var source = "abc 123"
-        var ast : DefaultHeterogeneousAST = Parser(grammar: testLanguage.grammar).build(source: source)
+        var ast = try! AbstractSyntaxTreeConstructor().build(source, using: testLanguage)
        
-        prettyPrint(nodes: ast.children, from: source)
+        print(ast.description)
         
         XCTAssertNotNil(ast.children.first?.token , "Basic parsing did not work")
 
         source = "abc "
-        ast = Parser(grammar: testLanguage.grammar).build(source: source)
-
-        prettyPrint(nodes: ast.children, from: source)
-
-        XCTAssert(ast.children.first?.children[0].matchedString(source) ?? "fail" == "abc" , "Letters node does not exist or contains the wrong value")
+        ast = try! AbstractSyntaxTreeConstructor().build(source, using: testLanguage)
+        
+        XCTAssert(ast.children.first?.matchedString ?? "fail" == "abc" , "Letters node does not exist or contains the wrong value")
 
         
         


### PR DESCRIPTION
The legacy and current APIs are now both available. The legacy API has been marked as deprecated and will generate build warnings for consumers using it. 

This deprecated API could be removed 0.3..<1.0, I haven't decided yet. 

This commit, due to its new API is intended to represent v2.0