### PR TITLE
Updated STLR documentation: @pinned -> @pin

### DIFF
--- a/Documentation/STLR.md
+++ b/Documentation/STLR.md
@@ -128,7 +128,7 @@ When your defined language is being parsed, if the element annotated with this f
     
 Will generate an error explaining why matching failed. 
 
-### @pinned
+### @pin
 
 When an optional non-transient element is not matched a node will be created regardless of whether or not the optional element was matched. It will also ensure that if this is the only non-transient child created for a node that it will be not be hoisted (normally if a node has only one child, the child is raised to the level of the parent to reduce complexity of the AST). 
 


### PR DESCRIPTION
Latest grammar in `master` branch accepts only `@pin` annotations, not `@pinned`, updated documentation accordingly.