### PR TITLE
Fixed broken formatting in installation link

### DIFF
--- a/Documentation/stlr-toolc.md
+++ b/Documentation/stlr-toolc.md
@@ -1,7 +1,7 @@
 # Index
 
  - [Usage](usage)
- - [Installation] (installation)
+ - [Installation](installation)
  - Tutorials
  	- [Bork - A command line text adventure using OysterKit and STLR](https://github.com/SwiftStudies/OysterKit/Documentation/Tutorials/Bork) 
 


### PR DESCRIPTION
Space between link description and the link itself prevented Markdown from rendering correctly.