### PR TITLE
Fixed ParseCommand.parseInput not using language argument

### DIFF
--- a/Sources/stlrc/Commands/Parse.swift
+++ b/Sources/stlrc/Commands/Parse.swift
@@ -60,11 +60,12 @@ class ParseCommand : Command, IndexableOptioned, IndexableParameterized, Grammar
     }
 
     func parseInput(language:Language, input:String) throws {
-        let ast = STLRParser(source: input).ast
+        let ctr = AbstractSyntaxTreeConstructor()
+        let ast = try ctr.build(input, using: language)
 
-        guard ast.errors.count == 0 else {
+        guard ctr.errors.count == 0 else {
             print("Parsing failed: ".color(.red))
-            for error in ast.errors {
+            for error in ctr.errors {
                 if let humanReadable = error as? HumanConsumableError {
                     print(humanReadable.formattedErrorMessage(in: input))
                 } else {


### PR DESCRIPTION
Turns out, when using parse command with a supplied grammar, `parseInput` function tried to parse the grammar itself, not the passed `input` with supplied `language`. This is fixed in this PR, also fully fixes #47.

I wasn't able to add tests for `ParseCommand` due to inscrutable linking errors when trying to import `stlrc` module in tests code, might be some configuration issue. Happy to write those test if we figure out how to link them correctly to `stlrc` module.