### PR TITLE
Fixed test message: expected 2 errors but reported 3

### DIFF
--- a/Tests/STLRTests/GrammarTest.swift
+++ b/Tests/STLRTests/GrammarTest.swift
@@ -346,7 +346,7 @@ class GrammarTest: XCTestCase {
         
         if case .constructionFailed(let errors) = rootError {
             guard errors.count == 2 else {
-                XCTFail("Expected 3 errors but got \(errors.count)\n\(errors)")
+                XCTFail("Expected 2 errors but got \(errors.count)\n\(errors)")
                 return
             }
             


### PR DESCRIPTION
In the line above guard was checking for 2 errors, but when this condition fails, it reports that it expected 3 errors.