### PR TITLE
Transient & Void Syntactic Sugar

### DIFF
--- a/Documentation/STLR.md
+++ b/Documentation/STLR.md
@@ -116,15 +116,33 @@ The next element will result in a token with the provided String value.
 
 ### @transient
 
-We do not always want tokens met to be included in the AST. If prefixed with @transient then the token will not be captured in the AST or stream. For example, if we do not want any newlines to be captured in our AST but we do need to capture both types we could define the following rule
+We do not always want tokens met to be included in the AST. If prefixed with @transient then the token will not be captured in the AST or stream. For example, if we do not want any newlines to be captured in our AST but we do need to capture both types of newline we could define the following rule
 
     @transient crlf = "\r\n" | "\n"
     
 However the match will still be included in the range of the parent node and any non-transient child nodes of the annotated node will be adopted by the parent node. If you wish to completely ignore the match and proceed with evaluation you should use the @void annotation. 
 
+You can also use the ```~``` as a prefix as a shortcut to this. It can be applied to either the declaration of a rule
+
+    ~crlf = "\r\n" | "\n"
+    
+Or inline for an element of a rule. For example
+
+    crlf = "\r\n" | "\n"
+    rule = code ~crlf
+
 ### @void
 
 When a token of this type is matched scanning will continue after the match but no nodes will be created and any children of a void node will be completely discarded. The range of this match will not be applied to the range of the parent. 
+
+As with transient annotations you can use a prefix, in this case ```-```, to simplify annotating either the rule itself
+
+    -quote = "'"
+    
+Or inline on an element of a rule's expression
+
+    quote = "'"
+    string = -quote stringBody -quote
 
 ### @error(String)
 

--- a/Documentation/STLR.md
+++ b/Documentation/STLR.md
@@ -118,7 +118,7 @@ The next element will result in a token with the provided String value.
 
 We do not always want tokens met to be included in the AST. If prefixed with @transient then the token will not be captured in the AST or stream. For example, if we do not want any newlines to be captured in our AST but we do need to capture both types we could define the following rule
 
-    @transient crlf = "\r\n"
+    @transient crlf = "\r\n" | "\n"
     
 However the match will still be included in the range of the parent node and any non-transient child nodes of the annotated node will be adopted by the parent node. If you wish to completely ignore the match and proceed with evaluation you should use the @void annotation. 
 

--- a/Resources/STLR.stlr
+++ b/Resources/STLR.stlr
@@ -41,7 +41,8 @@ ows                                             = whitespace*
 //
 quantifier                              = "*" | "+" | "?" | "-"
 negated                                 = "!"
-transient                               = "-"
+transient                               = "~"
+void                                    = "-"
 
 //
 // Parsing Control
@@ -120,7 +121,7 @@ expression whitespace*
 ")"
 identifier                              = /[:alpha:]\w*|_\w*/
 
-element                                 = annotations? (lookahead | transient)? negated? ( group | terminal | identifier ) quantifier?
+element                                 = annotations? (lookahead | transient | void)? negated? ( group | terminal | identifier ) quantifier?
 
 //
 // Expressions
@@ -141,7 +142,7 @@ expression                              = choice | sequence | element
 // Rule
 //
 @transient
-lhs                                             = whitespace* annotations? transient? identifier whitespace* assignmentOperators
+lhs                                             = whitespace* annotations? transient? void? identifier whitespace* assignmentOperators
 rule                                    = lhs whitespace* @error("Expected expression")expression whitespace*
 
 //

--- a/Resources/STLR.stlr
+++ b/Resources/STLR.stlr
@@ -37,7 +37,7 @@ ows                                             = whitespace*
 //definition                    = "const"       ows identifier ows "=" ows literal .whitespace* whitespace
 
 //
-// Quantifiers, does this still work?
+// Quantifiers
 //
 quantifier                              = "*" | "+" | "?" | "-"
 negated                                 = "!"

--- a/Sources/OysterKit/Parsing/Parser.swift
+++ b/Sources/OysterKit/Parsing/Parser.swift
@@ -1,13 +1,3 @@
-//
-//  Compiler.swift
-//  OysterKit
-//
-//  
-//  Copyright © 2016 RED When Excited. All rights reserved.
-//
-
-import Foundation
-
 //    Copyright (c) 2016, RED When Excited
 //    All rights reserved.
 //
@@ -31,6 +21,8 @@ import Foundation
 //    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 //    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 //    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
 
 /**
  A default implementation of a `Language`. AST construction is automatically provided by standard extensions to `Language`

--- a/Sources/STLR/STLR.swift
+++ b/Sources/STLR/STLR.swift
@@ -1,7 +1,7 @@
 // 
 // STLR Generated Swift File
 // 
-// Generated: 2018-07-13 18:46:45 +0000
+// Generated: 2018-07-14 05:14:15 +0000
 // 
 #if os(macOS)
 import Cocoa
@@ -40,7 +40,7 @@ enum STLR : Int, Token {
 		    }
 	}
 
-	case _transient = -1, `whitespace`, `ows`, `quantifier`, `negated`, `transient`, `lookahead`, `terminalBody`, `stringBody`, `string`, `terminalString`, `characterSetName`, `characterSet`, `rangeOperator`, `characterRange`, `number`, `boolean`, `literal`, `annotation`, `annotations`, `customLabel`, `definedLabel`, `label`, `regexDelimeter`, `startRegex`, `endRegex`, `regexBody`, `regex`, `terminal`, `group`, `identifier`, `element`, `assignmentOperators`, `or`, `then`, `choice`, `notNewRule`, `sequence`, `expression`, `lhs`, `rule`, `moduleName`, `moduleImport`, `mark`, `grammar`
+	case _transient = -1, `whitespace`, `ows`, `quantifier`, `negated`, `transient`, `void`, `lookahead`, `terminalBody`, `stringBody`, `string`, `terminalString`, `characterSetName`, `characterSet`, `rangeOperator`, `characterRange`, `number`, `boolean`, `literal`, `annotation`, `annotations`, `customLabel`, `definedLabel`, `label`, `regexDelimeter`, `startRegex`, `endRegex`, `regexBody`, `regex`, `terminal`, `group`, `identifier`, `element`, `assignmentOperators`, `or`, `then`, `choice`, `notNewRule`, `sequence`, `expression`, `lhs`, `rule`, `moduleName`, `moduleImport`, `mark`, `grammar`
 
 	func _rule(_ annotations: RuleAnnotations = [ : ])->Rule {
 		switch self {
@@ -60,7 +60,10 @@ enum STLR : Int, Token {
 			return "!".terminal(token: T.negated, annotations: annotations)
 		// transient
 		case .transient:
-			return "-".terminal(token: T.transient, annotations: annotations)
+			return "~".terminal(token: T.transient, annotations: annotations)
+		// void
+		case .void:
+			return "-".terminal(token: T.void, annotations: annotations)
 		// lookahead
 		case .lookahead:
 			return ">>".terminal(token: T.lookahead, annotations: annotations)
@@ -221,6 +224,7 @@ enum STLR : Int, Token {
 					[
 									T.lookahead._rule(),
 									T.transient._rule(),
+									T.void._rule(),
 									].oneOf(token: T._transient).optional(producing: T._transient),
 					T.negated._rule().optional(producing: T._transient),
 					[
@@ -321,6 +325,7 @@ enum STLR : Int, Token {
 					T.whitespace._rule([RuleAnnotation.void : RuleAnnotationValue.set]).repeated(min: 0, producing: T._transient),
 					T.annotations._rule().optional(producing: T._transient),
 					T.transient._rule().optional(producing: T._transient),
+					T.void._rule().optional(producing: T._transient),
 					T.identifier._rule(),
 					T.whitespace._rule([RuleAnnotation.void : RuleAnnotationValue.set]).repeated(min: 0, producing: T._transient),
 					T.assignmentOperators._rule(),

--- a/Sources/STLR/STLRAbstractSyntaxTree.swift
+++ b/Sources/STLR/STLRAbstractSyntaxTree.swift
@@ -33,7 +33,8 @@ struct STLRAbstractSyntaxTree {
         enum   AssignmentOperators : String, Decodable {
             case becomesEqualTo = "="
         }
-        
+        let transient : Quantifier?
+        let void : Quantifier?
         let identifier : String
         let assignmentOperators : AssignmentOperators
         let expression : Expression
@@ -63,6 +64,7 @@ struct STLRAbstractSyntaxTree {
         //These apply to all
         let negated  : Qualifier?
         let transient : Quantifier?
+        let void : Quantifier?
         let quantifier : Quantifier?
         let annotations : [Annotation]?
         let lookahead   : String?

--- a/Sources/STLR/STLRCompiler.swift
+++ b/Sources/STLR/STLRCompiler.swift
@@ -88,6 +88,15 @@ extension STLRAbstractSyntaxTree.Rule {
         if let annotations = try annotations?.map({ return try $0.compile(from:ast, into: scope)}) {
             symbolTableEntry.annotations = annotations
         }
+        
+        if let void = void, void == .void {
+            symbolTableEntry.annotations.append(STLRScope.ElementAnnotationInstance(STLRScope.ElementAnnotation.void, value: STLRScope.ElementAnnotationValue.set))
+        }
+        
+        if let transient = transient, transient == .transient {
+            symbolTableEntry.annotations.append(STLRScope.ElementAnnotationInstance(STLRScope.ElementAnnotation.transient, value: STLRScope.ElementAnnotationValue.set))
+        }
+        
         let grammarRule = STLRScope.GrammarRule(with: symbolTableEntry, try expression.compile(from:ast, into:scope), in: scope)
 
         // Update tables
@@ -171,6 +180,11 @@ extension STLRAbstractSyntaxTree.Element {
         var negated  = self.negated?.compile() ?? STLRScope.Modifier.one
         var quantifier  = self.quantifier?.compile() ?? STLRScope.Modifier.one
         var annotations = try self.annotations?.map({ return try $0.compile(from:ast, into: scope)}) ?? []
+
+        //Look for void sugar'd annotation
+        if void != nil {
+            annotations.append(STLRScope.ElementAnnotationInstance(STLRScope.ElementAnnotation.void, value: STLRScope.ElementAnnotationValue.set))
+        }
 
         //If there is no specific annotation and a transient mark (~) was given then create an annotation for it
         if transient && annotations[annotation: STLRScope.ElementAnnotation.transient] == nil{

--- a/Tests/STLRTests/STLRTests.swift
+++ b/Tests/STLRTests/STLRTests.swift
@@ -80,6 +80,42 @@ class STLRTest: XCTestCase {
         XCTAssertNil(try? AbstractSyntaxTreeConstructor().build(source, using: testLanguage))
     }
     
+    func testVoidSugar(){
+        let expectedAnnotations = [ RuleAnnotation.void : RuleAnnotationValue.set]
+        let rule = "-identifier = -\"/\""
+        let parser = STLRParser.init(source: rule)
+
+        guard let identifier = parser.ast.identifiers["identifier"] else {
+            XCTFail("Rule was not compiled \(parser.ast.errors)")
+            return
+        }
+        XCTAssertEqual(identifier.annotations.asRuleAnnotations,expectedAnnotations)
+        
+        if case let STLRScope.Expression.element(element) = identifier.grammarRule!.expression! {
+            XCTAssertEqual(element.elementAnnotations.asRuleAnnotations, expectedAnnotations)
+        } else {
+            XCTFail("Expected the identifier element to be an element")
+        }
+    }
+    
+    func testTransientSugar(){
+        let expectedAnnotations = [ RuleAnnotation.transient : RuleAnnotationValue.set]
+        let rule = "~identifier = ~(\"/\")"
+        let parser = STLRParser.init(source: rule)
+        
+        guard let identifier = parser.ast.identifiers["identifier"] else {
+            XCTFail("Rule was not compiled \(parser.ast.errors)")
+            return
+        }
+        XCTAssertEqual(identifier.annotations.asRuleAnnotations,[ RuleAnnotation.transient : RuleAnnotationValue.set])
+        
+        if case let STLRScope.Expression.element(element) = identifier.grammarRule!.expression! {
+            XCTAssertEqual(element.elementAnnotations.asRuleAnnotations, expectedAnnotations)
+        } else {
+            XCTFail("Expected the identifier element to be an element")
+        }
+    }
+    
     func testParseSelf(){
 ////        for bundle in Bundle.allBundles{
 ////            print("BUNDLE PATH: \(bundle)")


### PR DESCRIPTION
Added - and ~ prefixes for both identifier declarations and inline elements as sugar for @void and @transient respectively